### PR TITLE
DOP-5144: changed comment title for git-changed files plugin

### DIFF
--- a/git-changed-files/src/index.ts
+++ b/git-changed-files/src/index.ts
@@ -20,7 +20,7 @@ extension.addBuildEventHandler('onSuccess', ({ utils: { status, git } }) => {
 
   if (markdownList.length !== 0) {
     status.show({
-      title: 'URLs to Changed Files',
+      title: 'Staged Links to Changed Files',
       summary: markdownList.join('\n'),
     });
   }


### PR DESCRIPTION
[DOP-5144](https://jira.mongodb.org/secure/RapidBoard.jspa?rapidView=953&projectKey=DOP&view=detail&selectedIssue=DOP-5144&quickFilter=26777#)

I don't have any staging and/or testing links since I would need to create a temporary extension just to see a text change. I think its safe just to merge into main but if you have objections I can create the temporary extension to test.