### PR TITLE
DOP-5202: Create Netlify-test-deploy Slack command

### DIFF
--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -57,23 +57,22 @@ export default async (req: Request) => {
     const [repoName, branchName] = individualRepo.value.split('/');
     const jobTitle = `Slack deploy: repoName ${repoName}, branchName ${branchName}, by ${user}`;
     if (repoName && branchName) {
-      if (slackCommand === '/netlify-test-deploy') {
-        console.log(`Deploying branch ${branchName} of repo ${repoName}`);
-        // Tigger build on a frontend site ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal the request was received from
-        // TODO: DOP-5214, change value of slash commands and their associated build hooks to env vars retrieved from dbEnvVars
-        const resp = await axios.post(
-          `https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-          { repoName: repoName, branchName: branchName },
-        );
-        return;
-      }
-      if (slackCommand === '/netlify-deploy') {
-        const resp = await axios.post(
-          `https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-          { repoName: repoName, branchName: branchName },
-        );
-        return;
-      }
+      // TODO: DOP-5214, change value of the build hooks to env vars retrieved from dbEnvVars
+      console.log(`Deploying branch ${branchName} of repo ${repoName}`);
+      const TEST_WEBHOOK_URL =
+        'https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+';
+      const PROD_WEBHOOK_URL =
+        'https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+';
+
+      console.log(`Deploying branch ${branchName} of repo ${repoName}`);
+      // Trigger build on a frontend site ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal the request was received from
+      const resp = await axios.post(
+        slackCommand === '/netlify-test-deploy'
+          ? `${TEST_WEBHOOK_URL}${jobTitle}`
+          : `${PROD_WEBHOOK_URL}${jobTitle}`,
+        { repoName: repoName, branchName: branchName },
+      );
+      return;
     }
     throw new Error('Missing branchName or repoName');
   }

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -57,24 +57,26 @@ export default async (req: Request) => {
     const [repoName, branchName] = individualRepo.value.split('/');
     const jobTitle = `Slack deploy: repoName ${repoName}, branchName ${branchName}, by ${user}`;
     if (repoName && branchName) {
-      console.log(`Deploying branch ${branchName} of repo ${repoName}`);
-      // Tigger build on a frontend site ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal the request was received from
-      // TODO: DOP-5214, change value of slash commands and their associated build hooks to env vars retrieved from dbEnvVars
-      const resp = await axios.post(
-        `https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-        { repoName: repoName, branchName: branchName },
-      );
-      return;
+      if (slackCommand === '/netlify-test-deploy') {
+        console.log(`Deploying branch ${branchName} of repo ${repoName}`);
+        // Tigger build on a frontend site ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal the request was received from
+        // TODO: DOP-5214, change value of slash commands and their associated build hooks to env vars retrieved from dbEnvVars
+        const resp = await axios.post(
+          `https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
+          { repoName: repoName, branchName: branchName },
+        );
+        return;
+      }
+      if (slackCommand === '/netlify-deploy') {
+        const resp = await axios.post(
+          `https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
+          { repoName: repoName, branchName: branchName },
+        );
+        return;
+      }
     }
-    if (slackCommand === '/netlify-deploy') {
-      const resp = await axios.post(
-        `https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-        { repoName: repoName, branchName: branchName },
-      );
-      return;
-    }
+    throw new Error('Missing branchName or repoName');
   }
-  throw new Error('Missing branchName or repoName');
 };
 
 // Send message to user that their job has been enqueued (DOP-5096)

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -30,7 +30,7 @@ export default async (req: Request) => {
   // TODO: Create an interface for slack view_submission payloads
   const parsed = JSON.parse(decoded);
   console.log(JSON.stringify(parsed));
-  console.log(`keys: ${parsed.keys()}`);
+  console.log(`keys: ${Object.keys(parsed)}`);
 
   const user = parsed?.user?.username;
   const stateValues = parsed?.view?.state?.values;

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -38,9 +38,8 @@ export default async (req: Request) => {
     return response;
   }
 
-  const slackCommand = parsed.view?.private_metadata;
+  const slackCommand = parsed.view?.callback_id;
 
-  console.log(parsed.view?.callback_id);
   const user = parsed.user?.username;
   const stateValues = parsed.view?.state?.values;
   const selectedRepos =

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -40,6 +40,7 @@ export default async (req: Request) => {
 
   const slackCommand = parsed.view?.private_metadata;
 
+  console.log(parsed.view?.callback_id);
   const user = parsed.user?.username;
   const stateValues = parsed.view?.state?.values;
   const selectedRepos =

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -29,8 +29,6 @@ export default async (req: Request) => {
   const decoded = decodeURIComponent(requestBody).split('=')[1];
   // TODO: Create an interface for slack view_submission payloads
   const parsed = JSON.parse(decoded);
-  console.log(JSON.stringify(parsed));
-  console.log(`keys: ${Object.keys(parsed)}`);
 
   if (parsed?.type !== 'view_submission') {
     const response = new Response(
@@ -53,7 +51,6 @@ export default async (req: Request) => {
   //   parsed?.user?.id,
   // );
 
-  // TODO: send branch name, payload in POST request, DOP-5201
   console.log(`Selected repos: ${JSON.stringify(selectedRepos)}`);
 
   for (const individualRepo of selectedRepos) {

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -29,6 +29,8 @@ export default async (req: Request) => {
   const decoded = decodeURIComponent(requestBody).split('=')[1];
   // TODO: Create an interface for slack view_submission payloads
   const parsed = JSON.parse(decoded);
+  console.log(JSON.stringify(parsed));
+  console.log(`keys: ${parsed.keys()}`);
 
   const user = parsed?.user?.username;
   const stateValues = parsed?.view?.state?.values;

--- a/extensions/slack/src/functions/deploy-repos.mts
+++ b/extensions/slack/src/functions/deploy-repos.mts
@@ -57,28 +57,24 @@ export default async (req: Request) => {
     const [repoName, branchName] = individualRepo.value.split('/');
     const jobTitle = `Slack deploy: repoName ${repoName}, branchName ${branchName}, by ${user}`;
     if (repoName && branchName) {
-      // TODO: add other conditionals here to deploy based on branchName
       console.log(`Deploying branch ${branchName} of repo ${repoName}`);
-      if (slackCommand === '/netlify-test-deploy') {
-        // Currently: sends build hook to deploy to docs-frontend-dotcomstg site
-        // TODO: DOP-5202, Send conditionally to build hooks of different sites ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal request received from
-        // change value of slash commands and their associated build hooks to env vars retrieved from dbEnvVars
-        const resp = await axios.post(
-          `https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-          { repoName: repoName, branchName: branchName },
-        );
-        return;
-      }
-      if (slackCommand === '/netlify-deploy') {
-        const resp = await axios.post(
-          `https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
-          { repoName: repoName, branchName: branchName },
-        );
-        return;
-      }
+      // Tigger build on a frontend site ('docs-frontend-dotcomstg' or 'docs-frontend-dotcomprd') depending on which modal the request was received from
+      // TODO: DOP-5214, change value of slash commands and their associated build hooks to env vars retrieved from dbEnvVars
+      const resp = await axios.post(
+        `https://api.netlify.com/build_hooks/673bd8c7938ade69f9530ec5?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
+        { repoName: repoName, branchName: branchName },
+      );
+      return;
     }
-    throw new Error('Missing branchName or repoName');
+    if (slackCommand === '/netlify-deploy') {
+      const resp = await axios.post(
+        `https://api.netlify.com/build_hooks/6744e9fd3344dd3955ccf135?trigger_branch=main&trigger_title=deployHook+${jobTitle}`,
+        { repoName: repoName, branchName: branchName },
+      );
+      return;
+    }
   }
+  throw new Error('Missing branchName or repoName');
 };
 
 // Send message to user that their job has been enqueued (DOP-5096)

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -13,6 +13,7 @@ export default async (req: Request): Promise<Response> => {
   }
   const requestBody = await new Response(req.body).text();
   const key_val = getQSString(requestBody);
+  console.log(`key val: ${JSON.stringify(key_val)}`);
   const triggerId = key_val.trigger_id;
   const dbEnvVars = getDbConfig();
 

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -28,12 +28,9 @@ export default async (req: Request): Promise<Response> => {
     return new Response('Slack request not validated', { status: 400 });
   }
 
-  const dbName = command === '/netlify-test-deploy' ? 'pool_test' : 'pool';
-  console.log(dbName);
   const reposBranchesCollection = await getReposBranchesCollection({
     clusterZeroURI: dbEnvVars.ATLAS_CLUSTER0_URI,
-    // TODO: DOP-5202, Change this conditionally to 'pool' or 'pool_test' depending on which slash command has been triggered
-    databaseName: dbName,
+    databaseName: command === '/netlify-test-deploy' ? 'pool_test' : 'pool',
     collectionName: dbEnvVars.REPOS_BRANCHES_COLLECTION,
     extensionName: EXTENSION_NAME,
   });

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -15,8 +15,7 @@ export default async (req: Request): Promise<Response> => {
   const key_val = getQSString(requestBody);
   console.log(`key val: ${JSON.stringify(key_val)}`);
   const triggerId = key_val.trigger_id;
-  const command = key_val.command;
-  console.log(command, decodeURIComponent(command));
+  const command = decodeURIComponent(key_val.command);
   const dbEnvVars = getDbConfig();
 
   if (
@@ -44,6 +43,7 @@ export default async (req: Request): Promise<Response> => {
     repos: deployableRepos,
     triggerId,
     slackAuthToken: dbEnvVars.SLACK_AUTH_TOKEN,
+    slackCommand: command,
   });
 
   if (!response?.data?.ok) {

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -15,6 +15,8 @@ export default async (req: Request): Promise<Response> => {
   const key_val = getQSString(requestBody);
   console.log(`key val: ${JSON.stringify(key_val)}`);
   const triggerId = key_val.trigger_id;
+  const command = key_val.command;
+  console.log(command, decodeURIComponent(command));
   const dbEnvVars = getDbConfig();
 
   if (

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -13,7 +13,6 @@ export default async (req: Request): Promise<Response> => {
   }
   const requestBody = await new Response(req.body).text();
   const key_val = getQSString(requestBody);
-  console.log(`key val: ${JSON.stringify(key_val)}`);
   const triggerId = key_val.trigger_id;
   const command = decodeURIComponent(key_val.command);
   const dbEnvVars = getDbConfig();
@@ -29,10 +28,12 @@ export default async (req: Request): Promise<Response> => {
     return new Response('Slack request not validated', { status: 400 });
   }
 
+  const dbName = command === '/netlify-test-deploy' ? 'pool_test' : 'pool';
+  console.log(dbName);
   const reposBranchesCollection = await getReposBranchesCollection({
     clusterZeroURI: dbEnvVars.ATLAS_CLUSTER0_URI,
     // TODO: DOP-5202, Change this conditionally to 'pool' or 'pool_test' depending on which slash command has been triggered
-    databaseName: 'pool',
+    databaseName: dbName,
     collectionName: dbEnvVars.REPOS_BRANCHES_COLLECTION,
     extensionName: EXTENSION_NAME,
   });

--- a/extensions/slack/src/functions/display-modal.mts
+++ b/extensions/slack/src/functions/display-modal.mts
@@ -30,6 +30,7 @@ export default async (req: Request): Promise<Response> => {
 
   const reposBranchesCollection = await getReposBranchesCollection({
     clusterZeroURI: dbEnvVars.ATLAS_CLUSTER0_URI,
+    // TODO: DOP-5214, store these values as env var constants
     databaseName: command === '/netlify-test-deploy' ? 'pool_test' : 'pool',
     collectionName: dbEnvVars.REPOS_BRANCHES_COLLECTION,
     extensionName: EXTENSION_NAME,

--- a/extensions/slack/src/index.ts
+++ b/extensions/slack/src/index.ts
@@ -1,13 +1,12 @@
 // Documentation: https://sdk.netlify.com
 import { NetlifyExtension } from '@netlify/sdk';
 
-// TODO: Change this to use derived Extension class once "addFunctions" implementation is ready
+// TODO: DOP-5200, Change this to use derived Extension class once "addFunctions" implementation is ready
 const extension = new NetlifyExtension();
 
 extension.addFunctions('./src/functions', {
   prefix: 'slack',
   shouldInjectFunction: ({ name }) => {
-    console.log(`Function ${name} injected`);
     // If the function is not enabled, return early
     return !!process.env.SLACK_ENABLED;
   },

--- a/extensions/slack/src/utils/build-modal.ts
+++ b/extensions/slack/src/utils/build-modal.ts
@@ -4,12 +4,14 @@ export const displayModal = async ({
   repos,
   triggerId,
   slackAuthToken,
+  slackCommand,
 }: {
   repos: Array<repoOption>;
   triggerId: string;
   slackAuthToken: string;
+  slackCommand: string;
 }): Promise<AxiosResponse> => {
-  const repoOptView = getDropDownView(triggerId, repos);
+  const repoOptView = getDropDownView({ triggerId, repos, slackCommand });
   if (!slackAuthToken) {
     throw new Error('No Slack token provided');
   }
@@ -22,13 +24,19 @@ export const displayModal = async ({
   });
 };
 
-export function getDropDownView(
-  triggerId: string,
-  repos: Array<repoOption>,
-): dropdownView {
+export function getDropDownView({
+  triggerId,
+  repos,
+  slackCommand,
+}: {
+  triggerId: string;
+  repos: Array<repoOption>;
+  slackCommand: string;
+}): dropdownView {
   return {
     trigger_id: triggerId,
     view: {
+      private_metadata: slackCommand,
       type: 'modal',
       title: {
         type: 'plain_text',
@@ -93,6 +101,7 @@ export type dropdownView = {
     title: slackBlock;
     submit: slackBlock;
     close: slackBlock;
+    private_metadata: string;
     blocks: [
       {
         type: 'input';

--- a/extensions/slack/src/utils/build-modal.ts
+++ b/extensions/slack/src/utils/build-modal.ts
@@ -37,7 +37,7 @@ export function getDropDownView({
     trigger_id: triggerId,
     view: {
       private_metadata: slackCommand,
-      callback_id: 'testing id',
+      callback_id: slackCommand,
       type: 'modal',
       title: {
         type: 'plain_text',

--- a/extensions/slack/src/utils/build-modal.ts
+++ b/extensions/slack/src/utils/build-modal.ts
@@ -36,7 +36,6 @@ export function getDropDownView({
   return {
     trigger_id: triggerId,
     view: {
-      private_metadata: slackCommand,
       callback_id: slackCommand,
       type: 'modal',
       title: {
@@ -102,7 +101,6 @@ export type dropdownView = {
     title: slackBlock;
     submit: slackBlock;
     close: slackBlock;
-    private_metadata: string;
     callback_id: string;
     blocks: [
       {

--- a/extensions/slack/src/utils/build-modal.ts
+++ b/extensions/slack/src/utils/build-modal.ts
@@ -37,6 +37,7 @@ export function getDropDownView({
     trigger_id: triggerId,
     view: {
       private_metadata: slackCommand,
+      callback_id: 'testing id',
       type: 'modal',
       title: {
         type: 'plain_text',
@@ -102,6 +103,7 @@ export type dropdownView = {
     submit: slackBlock;
     close: slackBlock;
     private_metadata: string;
+    callback_id: string;
     blocks: [
       {
         type: 'input';

--- a/extensions/slack/src/utils/getRepos.ts
+++ b/extensions/slack/src/utils/getRepos.ts
@@ -27,7 +27,9 @@ export const buildRepoGroups = async (
         options.push({
           text: {
             type: 'plain_text',
-            text: active ? branchName : `(!inactive) ${branchName}`,
+            text: active
+              ? `${repoName}/${branchName}`
+              : `(!inactive) ${repoName}/${branchName}`,
           },
           value: `${repoName}/${branchName}`,
         });


### PR DESCRIPTION
### TICKET
[DOP-5202](https://jira.mongodb.org/browse/DOP-5202)
Create Netlify-test-deploy Slack command

### NOTES
We now have two slack deploy commands part of the same Slack app: Netlify-deploy and Netlify-test-deploy
If the deploy modal is opened from Netlify-test-deploy, we send off the build hook to `docs-frontend-dotcomstg` with the repo name and branch name in the payload body
If the deploy modal is opened from Netlify-deploy, we send off the build hook to `docs-frontend-dotcomprd` with the repo name and branch name in the payload body

The slack modal works for both commands for all repos under the `mongodb` org (`10gen` org repos are a work in progress).

