### PR TITLE
DOP-5128: Adding alias information to bucket prefixes to upload in s3

### DIFF
--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -8,7 +8,6 @@ import { getProperties } from './getProperties';
 import type { ConfigEnvironmentVariables } from 'util/extension';
 import type { StaticEnvVars } from 'util/assertDbEnvVars';
 
-// use this function instead
 const getDbNames = (
   env: Environments,
 ): { snootyDb: SnootyDBName; searchDb: SearchDBName; poolDb: PoolDBName } => {

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -8,7 +8,7 @@ export const mutRedirectsAndPublish = async (
 ): Promise<void> => {
   // Get it from pool.docsets to get bucket
   const docsetEntry = configEnvironment?.DOCSET_ENTRY;
-  const aliasEntry = configEnvironment?.BRANCH_ENTRY;
+  const branchEntry = configEnvironment?.BRANCH_ENTRY;
   if (!docsetEntry) {
     throw new Error ("Unable to retrive DOCSET_ENTRY");
   }

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -19,11 +19,14 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfylly got branch_entry', branchEntry);
   
   // Get the array of the all the possible alisas 
-  const urlAliases = branchEntry?.urlAliases;
+  let urlAliases = branchEntry?.urlAliases;
 
   // Add current branch  to list of aliases
   if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
     urlAliases.push(branchEntry.gitBranchName);
+  }
+  if (!urlAliases) {
+    urlAliases = [''];
   }
   console.log('The urlAliases are', urlAliases);
 

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -19,11 +19,15 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfylly got branch_entry', branchEntry);
   
   // Get the array of the all the possible alisas 
-  const urlAliases = branchEntry.urlAliases ?  branchEntry.urlAliases :  [''] ;
+  // using slice() to create shallow copy so i dont get errors froom netlify about trying to write a read-only variable
+  const urlAliases = branchEntry.urlAliases ? branchEntry.urlAliases.slice() : [];
 
   // Add current branch  to list of aliases
   if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
     urlAliases.push(branchEntry.gitBranchName);
+  }
+  if (urlAliases.length === 0) {
+    urlAliases.push('');
   }
 
   console.log('The urlAliases are', urlAliases);

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -67,7 +67,7 @@ export const mutRedirectsAndPublish = async (
   for (const alias of urlAliases) {
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
-    const prefix = alias ? `/${docsetEntry?.prefix?.dotcomstg}/${alias}`: `/${docsetEntry?.prefix?.dotcomstg}`;
+    const prefix = alias ? `/${docsetEntry.prefix.dotcomstg}/${alias}`: `/${docsetEntry.prefix.dotcomstg}`;
     process.env.PATH_PREFIX = prefix;
     await run.command('npm ci');
     await run.command('npm run clean');

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -19,15 +19,13 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfylly got branch_entry', branchEntry);
   
   // Get the array of the all the possible alisas 
-  let urlAliases = branchEntry?.urlAliases;
+  const urlAliases = branchEntry.urlAliases ?  branchEntry.urlAliases :  [''] ;
 
   // Add current branch  to list of aliases
   if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
     urlAliases.push(branchEntry.gitBranchName);
   }
-  if (!urlAliases) {
-    urlAliases = [''];
-  }
+
   console.log('The urlAliases are', urlAliases);
 
   // We want to copy the snooty folder and run `npm run build` instead of `npm run build:no-prefix` as it does in the build.sh

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -21,14 +21,14 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfylly got branch_entry', branchEntry);
 
   // get the array of the all the possible alisas 
-  const branchNames = branchEntry?.urlAliases;
+  const urlAliases = branchEntry?.urlAliases;
 
   // add current branch  to list of aliases
-  if (!!(branchEntry?.publishOriginalBranchName) && (!branchNames.includes(branchEntry.gitBranchName))) {
-    branchNames.push(branchEntry.gitBranchName);
+  if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
+    urlAliases.push(branchEntry.gitBranchName);
   }
 
-  console.log('the branch names are', branchNames);
+  console.log('the branch names are', urlAliases);
 
   // We want to copy the snooty folder and run `npm run build` instead of `npm run build:no-prefix` as it does in the build.sh
   // We do this so when we run mut-publish we are able to uplaod the correct files with the correct paths
@@ -91,11 +91,11 @@ export const mutRedirectsAndPublish = async (
     throw new Error('Credentials not found');
   }
 
-  for (const branch of branchNames) {
-    console.log('the current branch is', branch);
+  for (const alias of urlAliases) {
+    console.log('the current branch is', alias);
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
-    const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${branch}`;
+    const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${alias}`;
     process.env.PATH_PREFIX = prefix;
     await run.command('npm ci');
     await run.command('npm run clean');
@@ -108,8 +108,9 @@ export const mutRedirectsAndPublish = async (
       console.log('the repo name is', configEnvironment.REPO_ENTRY?.repoName);
       await run.command(
         `${process.cwd()}/mut/mut-redirects ${configEnvironment.REPO_ENTRY?.repoName}/config/redirects -o public/.htaccess`,
-
       );
+    } catch (e) {
+      console.log(`Error occurred while running mut-redirects: ${e}`);
     }
 
     //Running mut-publish ----------------------------------------------------------

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -20,15 +20,15 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfully got docsets_entry:', docsetEntry);
   console.log('Succesfylly got branch_entry', branchEntry);
 
-  // get the array of the all the possible alisas 
+  // Get the array of the all the possible alisas 
   const urlAliases = branchEntry?.urlAliases;
 
-  // add current branch  to list of aliases
+  // Add current branch  to list of aliases if needed
   if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
     urlAliases.push(branchEntry.gitBranchName);
   }
 
-  console.log('the branch names are', urlAliases);
+  console.log('The aliases names are', urlAliases);
 
   // We want to copy the snooty folder and run `npm run build` instead of `npm run build:no-prefix` as it does in the build.sh
   // We do this so when we run mut-publish we are able to uplaod the correct files with the correct paths
@@ -92,7 +92,6 @@ export const mutRedirectsAndPublish = async (
   }
 
   for (const alias of urlAliases) {
-    console.log('the current branch is', alias);
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
     const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${alias}`;

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -8,7 +8,7 @@ export const mutRedirectsAndPublish = async (
   configEnvironment: ConfigEnvironmentVariables,
   run: NetlifyPluginUtils['run'],
 ): Promise<void> => {
-  // Get in from pool.docsets to get bucket
+  // Get it from pool.docsets to get bucket
   const docsetEntry = configEnvironment?.DOCSET_ENTRY;
   const branchEntry = configEnvironment?.BRANCH_ENTRY;
   if (!docsetEntry) {

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -65,7 +65,7 @@ export const mutRedirectsAndPublish = async (
     console.log('the current alias is', alias);
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
-    const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${alias}`;
+    const prefix = alias ? `/${docsetEntry?.prefix?.dotcomstg}/${alias}`: `/${docsetEntry?.prefix?.dotcomstg}`;
     process.env.PATH_PREFIX = prefix;
     await run.command('npm ci');
     await run.command('npm run clean');

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -16,7 +16,7 @@ export const mutRedirectsAndPublish = async (
     throw new Error ("Unable to retrive BRANCH_ENTRY");
   }
   console.log('Succesfully got docsets_entry:', docsetEntry);
-  console.log('Succesfylly got branch_entry', branchEntry);
+  console.log('Succesfully got branch_entry', branchEntry);
   
   // Get the array of the all the possible alisas 
   // using slice() to create shallow copy so i dont get errors froom netlify about trying to write a read-only variable

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -24,7 +24,7 @@ export const mutRedirectsAndPublish = async (
   const branchNames = branchEntry?.urlAliases;
 
   // add current branch  to list of aliases
-  if (!!(branchEntry?.publishOriginalBranchName)) {
+  if (!!(branchEntry?.publishOriginalBranchName) && (!branchNames.includes(branchEntry.gitBranchName))) {
     branchNames.push(branchEntry.gitBranchName);
   }
 
@@ -65,6 +65,7 @@ export const mutRedirectsAndPublish = async (
   }
 
   for (const branch of branchNames) {
+    console.log('the current branch is', branch);
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
     const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${branch}`;

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -1,16 +1,14 @@
 import type { ConfigEnvironmentVariables } from 'util/extension';
 import type { NetlifyPluginUtils } from '@netlify/build';
-
 const MUT_VERSION = process.env.MUT_VERSION;
 const MANIFEST_PATH = `${process.cwd()}/bundle.zip`;
-
 export const mutRedirectsAndPublish = async (
   configEnvironment: ConfigEnvironmentVariables,
   run: NetlifyPluginUtils['run'],
 ): Promise<void> => {
   // Get it from pool.docsets to get bucket
   const docsetEntry = configEnvironment?.DOCSET_ENTRY;
-  const branchEntry = configEnvironment?.BRANCH_ENTRY;
+  const aliasEntry = configEnvironment?.BRANCH_ENTRY;
   if (!docsetEntry) {
     throw new Error ("Unable to retrive DOCSET_ENTRY");
   }
@@ -19,44 +17,29 @@ export const mutRedirectsAndPublish = async (
   }
   console.log('Succesfully got docsets_entry:', docsetEntry);
   console.log('Succesfylly got branch_entry', branchEntry);
-
+  
   // Get the array of the all the possible alisas 
   const urlAliases = branchEntry?.urlAliases;
 
-  // Add current branch  to list of aliases if needed
+  // Add current branch  to list of aliases
   if (!!(branchEntry?.publishOriginalBranchName) && (!urlAliases.includes(branchEntry.gitBranchName))) {
     urlAliases.push(branchEntry.gitBranchName);
   }
-
-  console.log('The aliases names are', urlAliases);
+  console.log('The urlAliases are', urlAliases);
 
   // We want to copy the snooty folder and run `npm run build` instead of `npm run build:no-prefix` as it does in the build.sh
   // We do this so when we run mut-publish we are able to uplaod the correct files with the correct paths
   await run.command('rm -f -r running-mut');
   await run.command('mkdir -p running-mut');
-
-  if (configEnvironment?.SITE_NAME === 'mongodb-snooty') {
-    // Since mongodb-snooty is not a content repo the file structure is different and needs to be treated as such
+  // TODO: this should also happen for dotcomprd if configEnvironment.ENV == dotcomstg or (dotcomprd)
+  if (configEnvironment?.ENV === 'dotcomstg') {
     await run.command('mkdir -p running-mut/snooty');
     await run.command(
       `rsync -q -i -av --progress  ${process.cwd()} ${process.cwd()}/running-mut/snooty --exclude node_modules --exclude .cache --exclude running-mut`,
     );
     process.chdir(`${process.cwd()}/running-mut/snooty/repo`);
-  } else {
-    await run.command('cp -r snooty running-mut');
-    process.chdir(`${process.cwd()}/running-mut/snooty`);
-  }
+  } 
 
-  process.env.GATSBY_MANIFEST_PATH = MANIFEST_PATH;
-  // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
-  process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.dotcomstg}`;
-  process.env.GATSBY_PARSER_USER = 'buildbot';
-  
-  await run.command('npm ci');
-  await run.command('npm run clean');
-  await run.command('npm run build');
-
-  // Running mut-redirects -------------------------------------------------------
   console.log('Downloading Mut...', configEnvironment?.SITE_NAME);
   await run('curl', [
     '-L',
@@ -64,34 +47,19 @@ export const mutRedirectsAndPublish = async (
     'mut.zip',
     `https://github.com/mongodb/mut/releases/download/v${MUT_VERSION}/mut-v${MUT_VERSION}-linux_x86_64.zip`,
   ]);
-
   await run.command('unzip -d . -qq mut.zip');
-
-  try {
-    console.log('Running mut-redirects...');
-    // TODO: Change hard coded `docs-landing` to whatever repo is being built after DOP-5159 is completed
-    const redirectPath =
-      configEnvironment.SITE_NAME === 'mongodb-snooty'
-        ? 'docs-landing/config/redirects'
-        : '../../config/redirects';
-    await run.command(
-      `${process.cwd()}/mut/mut-redirects ${redirectPath} -o public/.htaccess`,
-    );
-  } catch (e) {
-    console.log(`Error occurred while running mut-redirects: ${e}`);
-  }
-
-  //Running mut-publish ----------------------------------------------------------
-
+ 
+  process.env.GATSBY_MANIFEST_PATH = MANIFEST_PATH;
+  process.env.GATSBY_PARSER_USER = 'buildbot';
   //TODO: Mut and populate-metadata extensions use different env variable names for the same values (set to team wide in future)
   process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_S3_SECRET_ACCESS_KEY;
   process.env.AWS_ACCESS_KEY_ID = process.env.AWS_S3_ACCESS_KEY_ID;
-
   if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
     throw new Error('Credentials not found');
   }
 
   for (const alias of urlAliases) {
+    console.log('the current alias is', alias);
     // Building snooty ------------------------------------------------------------
     // TODO: When uploaded to prod, run this command instead: process.env.PATH_PREFIX = `/${docsetEntry?.prefix?.[configEnvironment.ENV]}`; (DOP-5178)
     const prefix = `/${docsetEntry?.prefix?.dotcomstg}/${alias}`;
@@ -99,7 +67,6 @@ export const mutRedirectsAndPublish = async (
     await run.command('npm ci');
     await run.command('npm run clean');
     await run.command('npm run build');
-
     // Running mut-redirects -------------------------------------------------------
     try {
       console.log('Running mut-redirects...');
@@ -111,10 +78,8 @@ export const mutRedirectsAndPublish = async (
     } catch (e) {
       console.log(`Error occurred while running mut-redirects: ${e}`);
     }
-
     //Running mut-publish ----------------------------------------------------------
     console.log('Start of the mut-publish plugin -----------');
-
     /*Usage: mut-publish <source> <bucket> --prefix=prefix
                       (--stage|--deploy)
                       [--all-subdirectories]
@@ -129,7 +94,6 @@ export const mutRedirectsAndPublish = async (
           `DocsetEntry information missing. bucket: ${docsetEntry?.bucket}, ...etc`,
         );
       }
-
       // TODO: In future we change to docsetEntry?.prefix?.[configEnvironment.ENV] and docsetEntry?.url?.[configEnvironment.ENV] (DOP-5178)
       await run(
         `${process.cwd()}/mut/mut-publish`,

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -18,7 +18,7 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfully got docsets_entry:', docsetEntry);
   console.log('Succesfully got branch_entry', branchEntry);
   
-  // Get the array of the all the possible alisas 
+  // Get the array of the all the possible aliases 
   // using slice() to create shallow copy so i dont get errors froom netlify about trying to write a read-only variable
   const urlAliases = branchEntry.urlAliases ? branchEntry.urlAliases.slice() : [];
 

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -19,7 +19,7 @@ export const mutRedirectsAndPublish = async (
   console.log('Succesfully got branch_entry', branchEntry);
   
   // Get the array of the all the possible aliases 
-  // using slice() to create shallow copy so i dont get errors froom netlify about trying to write a read-only variable
+  // using slice() to create shallow copy so i dont get errors from netlify about trying to write a read-only variable
   const urlAliases = branchEntry.urlAliases ? branchEntry.urlAliases.slice() : [];
 
   // Add current branch  to list of aliases

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -28,6 +28,7 @@ export const mutRedirectsAndPublish = async (
     branchNames.push(branchEntry.gitBranchName);
   }
 
+  console.log('the branch names are', branchNames);
   // We want to copy the snooty folder and run `npm run build` instead of `npm run build:no-prefix` as it does in the build.sh
   // We do this so when we run mut-publish we are able to uplaod the correct files with the correct paths
   await run.command('rm -f -r running-mut');

--- a/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
+++ b/extensions/redirects-and-publish/src/mutRedirectsAndPublish.ts
@@ -22,6 +22,7 @@ export const mutRedirectsAndPublish = async (
   // TODOOOOO
   // create funciton that pass the brnachentry and return all the branchNames
   // changes variables to constants that make sense
+  // hello 
   console.log("the branch entry is ", branchEntry);
   const branchNames = branchEntry?.urlAliases;
 

--- a/libs/util/src/databaseConnection/types.ts
+++ b/libs/util/src/databaseConnection/types.ts
@@ -35,6 +35,8 @@ export interface BranchEntry {
   urlSlug: string;
   isStableBranch: boolean;
   active: boolean;
+  urlAliases: Array<string>;
+  publishOriginalBranchName: boolean;
 }
 
 export interface ReposBranchesDocument {


### PR DESCRIPTION
adding functionality so that mut-redirects can publish into the correct subdirectories based on aliases

Test
* use the slack app `/netlify-test-deploy` with a site that has more then one alias. you can check `pool_test.repos_branches` for this information. then follow the deploy on netlify to make sure it deploys correctly. Currently `redirects-and-publish` extension is set to this branch so it should be good to test on netlify. 