### PR TITLE
DOP-5198: remove scripts from HTML file

### DIFF
--- a/extensions/offline-snooty/src/convertGatsbyToHtml/fileHandler.ts
+++ b/extensions/offline-snooty/src/convertGatsbyToHtml/fileHandler.ts
@@ -23,6 +23,14 @@ function updateToRelativePaths(nodeList: Node[], prefix: string) {
   }
 }
 
+function removeScripts(document: Window['document']) {
+  const query = 'script:not(.structured_data)';
+  const scripts = document.querySelectorAll(query);
+  for (const script of scripts) {
+    script.parentNode?.removeChild(script);
+  }
+}
+
 export const handleHtmlFile = async (
   filepath: string,
   relativePath: string,
@@ -37,8 +45,9 @@ export const handleHtmlFile = async (
 
   const links = document.querySelectorAll('a');
   const images = document.querySelectorAll('img');
-  // TODO: should handle background-image url as well
+  // TODO as part of DOP-5196
   updateToRelativePaths([...links, ...images], relativePath ?? './');
+  removeScripts(document);
 
   console.log('writing file html ', filepath);
 


### PR DESCRIPTION
DOP-5198

This PR removes <script> tags from HTML output of snooty.
The first part of the AC will be a no op since this small script will remove sourcing of any scripts (local or remote) that are not related to structured data

Attempted to deploy and log this, but [failing at populate metadata](https://app.netlify.com/sites/iridescent-babka-0105eb/deploys/67508c59e5bd964ba1f00d7f#L108)