### PR TITLE
DOP-5238 Clone docs-laravel submodule for Netlify deploys

### DIFF
--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -101,8 +101,8 @@ const cloneContentRepo = async ({
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command('rsync -r -q -av laravel-mongodb/docs source');
-    await run.command('ls source');
+    await run.command(`cp -r laravel-mongodb/docs ${process.cwd()}/source`);
+    await run.command('ls source/docs');
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -101,7 +101,7 @@ const cloneContentRepo = async ({
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command(`cp -r laravel-mongodb/docs ${process.cwd()}/source`);
+    await run.command('cp -r laravel-mongodb/docs source');
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -93,7 +93,6 @@ const cloneContentRepo = async ({
   );
 
   if (repoName === 'docs-laravel') {
-    await run.command(`cd ${repoName}`);
     await run.command('ls');
     await run.command('git submodule update --init --recursive');
     await run.command('echo submdoule updated successfully');

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -93,9 +93,10 @@ const cloneContentRepo = async ({
   );
 
   if (repoName === 'docs-laravel') {
+    await run.command(`cd ${process.cwd()}/${repoName}`);
     await run.command('ls');
     await run.command('git submodule update --init --recursive');
-    await run.command('echo submdoule updated successfully');
+    await run.command('echo submodule updated successfully');
 
     await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
     await run.command('ls');

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -84,7 +84,7 @@ const cloneContentRepo = async ({
   branchName: string;
   orgName: string;
 }) => {
-  if (fs.existsSync(`${repoName}`)) {
+  if (fs.existsSync(repoName)) {
     await run.command(`rm -r ${repoName}`);
   }
 
@@ -102,7 +102,7 @@ const cloneContentRepo = async ({
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
     await run.command('cp -r laravel-mongodb/docs source');
-    await run.command('echo docs-laravel submodule updated successfully');
+    console.log('docs-laravel submodule updated successfully');
     process.chdir('..');
   }
 };

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -99,6 +99,7 @@ const cloneContentRepo = async ({
     await run.command('echo submodule updated successfully');
 
     await run.command('mkdir source');
+    await run.command('ls');
     await run.command('cp -r laravel-mongodb/docs/* source');
     await run.command('ls');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -101,8 +101,7 @@ const cloneContentRepo = async ({
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command(`cp -r laravel-mongodb/docs ${process.cwd()}/source`);
-    await run.command(`ls ${process.cwd()}/source`);
+    await run.command('cp -r laravel-mongodb/docs /source');
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -93,6 +93,7 @@ const cloneContentRepo = async ({
   );
 
   if (repoName === 'docs-laravel') {
+    await run.command(`cd ${repoName}`);
     await run.command('git submodule update --init --recursive');
     await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
     await run.command('ls');

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -97,17 +97,14 @@ const cloneContentRepo = async ({
     await run.command(`rm -r ${repoName}/.git/config`);
   }
 
+  // Docs-laravel requires a submodule to build
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command('echo submodule updated successfully');
-
-    await run.command('mkdir source');
-    await run.command('ls laravel-mongodb');
     await run.command(
       `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs source`,
     );
-    await run.command('ls');
+    await run.command('echo docs-laravel submodule updated successfully');
   }
 };
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -99,7 +99,6 @@ const cloneContentRepo = async ({
 
   // Docs-laravel requires a submodule to build
   if (repoName === 'docs-laravel') {
-    process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive', {
       cwd: repoName,
     });

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -100,10 +100,13 @@ const cloneContentRepo = async ({
   // Docs-laravel requires a submodule to build
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
-    await run.command('git submodule update --init --recursive');
-    await run.command('cp -r laravel-mongodb/docs source');
+    await run.command('git submodule update --init --recursive', {
+      cwd: repoName,
+    });
+    await run.command('cp -r laravel-mongodb/docs source', {
+      cwd: repoName,
+    });
     console.log('docs-laravel submodule updated successfully');
-    process.chdir('..');
   }
 };
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -84,9 +84,11 @@ const cloneContentRepo = async ({
   branchName: string;
   orgName: string;
 }) => {
-  if (fs.existsSync(`${process.cwd()}/${repoName}`)) {
-    await run.command(`rm -r ${process.cwd()}/${repoName}`);
+  if (fs.existsSync(`${repoName}`)) {
+    await run.command(`rm -r ${repoName}`);
   }
+
+  await run.command('ls');
 
   await run.command(
     `git clone -b ${branchName} https://${process.env.GITHUB_BOT_USERNAME}:${process.env.GITHUB_BOT_PWD}@github.com/${orgName}/${repoName}.git -s`,
@@ -101,9 +103,7 @@ const cloneContentRepo = async ({
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command(
-      `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs source`,
-    );
+    await run.command('rsync -r -q -av laravel-mongodb/docs source');
     await run.command('echo docs-laravel submodule updated successfully');
   }
 };

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -101,7 +101,7 @@ const cloneContentRepo = async ({
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
-    await run.command('cp -r laravel-mongodb/docs /source');
+    await run.command(`cp -r laravel-mongodb/docs ${process.cwd()}/source`);
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -92,9 +92,10 @@ const cloneContentRepo = async ({
     `git clone -b ${branchName} https://${process.env.GITHUB_BOT_USERNAME}:${process.env.GITHUB_BOT_PWD}@github.com/${orgName}/${repoName}.git -s`,
   );
 
-  if (repoName === 'DOCS_LARAVEL') {
+  if (repoName === 'docs-laravel') {
     await run.command('git submodule update --init --recursive');
     await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
+    await run.command('ls');
   }
 
   // Remove git config as it stores the connection string in plain text

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -88,8 +88,6 @@ const cloneContentRepo = async ({
     await run.command(`rm -r ${repoName}`);
   }
 
-  await run.command('ls');
-
   await run.command(
     `git clone -b ${branchName} https://${process.env.GITHUB_BOT_USERNAME}:${process.env.GITHUB_BOT_PWD}@github.com/${orgName}/${repoName}.git -s`,
   );

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -92,6 +92,11 @@ const cloneContentRepo = async ({
     `git clone -b ${branchName} https://${process.env.GITHUB_BOT_USERNAME}:${process.env.GITHUB_BOT_PWD}@github.com/${orgName}/${repoName}.git -s`,
   );
 
+  // Remove git config as it stores the connection string in plain text
+  if (fs.existsSync(`${repoName}/.git/config`)) {
+    await run.command(`rm -r ${repoName}/.git/config`);
+  }
+
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
@@ -103,11 +108,6 @@ const cloneContentRepo = async ({
       `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs source`,
     );
     await run.command('ls');
-  }
-
-  // Remove git config as it stores the connection string in plain text
-  if (fs.existsSync(`${repoName}/.git/config`)) {
-    await run.command(`rm -r ${repoName}/.git/config`);
   }
 };
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -92,6 +92,11 @@ const cloneContentRepo = async ({
     `git clone -b ${branchName} https://${process.env.GITHUB_BOT_USERNAME}:${process.env.GITHUB_BOT_PWD}@github.com/${orgName}/${repoName}.git -s`,
   );
 
+  if (repoName === 'DOCS_LARAVEL') {
+    await run.command('git submodule update --init --recursive');
+    await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
+  }
+
   // Remove git config as it stores the connection string in plain text
   if (fs.existsSync(`${repoName}/.git/config`)) {
     await run.command(`rm -r ${repoName}/.git/config`);

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -102,7 +102,7 @@ const cloneContentRepo = async ({
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
     await run.command(`cp -r laravel-mongodb/docs ${process.cwd()}/source`);
-    await run.command('ls source/docs');
+    await run.command(`ls ${process.cwd()}/source`);
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -94,7 +94,10 @@ const cloneContentRepo = async ({
 
   if (repoName === 'docs-laravel') {
     await run.command(`cd ${repoName}`);
+    await run.command('ls');
     await run.command('git submodule update --init --recursive');
+    await run.command('echo submdoule updated successfully');
+
     await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
     await run.command('ls');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -98,7 +98,8 @@ const cloneContentRepo = async ({
     await run.command('git submodule update --init --recursive');
     await run.command('echo submodule updated successfully');
 
-    await run.command('mkdir source && cp -r laravel-mongodb/docs/* source');
+    await run.command('mkdir source');
+    await run.command('cp -r laravel-mongodb/docs/* source');
     await run.command('ls');
   }
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -103,6 +103,7 @@ const cloneContentRepo = async ({
     await run.command('git submodule update --init --recursive');
     await run.command('rsync -r -q -av laravel-mongodb/docs source');
     await run.command('echo docs-laravel submodule updated successfully');
+    process.chdir('..');
   }
 };
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -94,12 +94,11 @@ const cloneContentRepo = async ({
 
   if (repoName === 'docs-laravel') {
     process.chdir(`${repoName}`);
-    await run.command('ls');
     await run.command('git submodule update --init --recursive');
     await run.command('echo submodule updated successfully');
 
     await run.command('mkdir source');
-    await run.command('ls');
+    await run.command('ls laravel-mongodb');
     await run.command('cp -r laravel-mongodb/docs/* source');
     await run.command('ls');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -99,7 +99,9 @@ const cloneContentRepo = async ({
 
     await run.command('mkdir source');
     await run.command('ls laravel-mongodb');
-    await run.command('cp -r laravel-mongodb/docs/* source');
+    await run.command(
+      `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs/* source`,
+    );
     await run.command('ls');
   }
 

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -100,7 +100,7 @@ const cloneContentRepo = async ({
     await run.command('mkdir source');
     await run.command('ls laravel-mongodb');
     await run.command(
-      `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs/* source`,
+      `rsync -r -q -av ${process.cwd()}/laravel-mongodb/docs source`,
     );
     await run.command('ls');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -102,6 +102,7 @@ const cloneContentRepo = async ({
     process.chdir(`${repoName}`);
     await run.command('git submodule update --init --recursive');
     await run.command('rsync -r -q -av laravel-mongodb/docs source');
+    await run.command('ls source');
     await run.command('echo docs-laravel submodule updated successfully');
     process.chdir('..');
   }

--- a/extensions/populate-metadata/src/updateConfig.ts
+++ b/extensions/populate-metadata/src/updateConfig.ts
@@ -85,7 +85,7 @@ const cloneContentRepo = async ({
   orgName: string;
 }) => {
   if (fs.existsSync(`${process.cwd()}/${repoName}`)) {
-    await run.command(`rm -r ${repoName}`);
+    await run.command(`rm -r ${process.cwd()}/${repoName}`);
   }
 
   await run.command(
@@ -93,7 +93,7 @@ const cloneContentRepo = async ({
   );
 
   if (repoName === 'docs-laravel') {
-    await run.command(`cd ${process.cwd()}/${repoName}`);
+    process.chdir(`${repoName}`);
     await run.command('ls');
     await run.command('git submodule update --init --recursive');
     await run.command('echo submodule updated successfully');


### PR DESCRIPTION
### TICKET 
[DOP-5238](https://jira.mongodb.org/browse/DOP-5238) Clone docs-laravel submodule for Netlify deploys

### NOTES
The [docs-laravel](https://github.com/10gen/docs-laravel) repo has a submodule that is necessary for it to build properly. The repo already has a special build script for the docs-laravel Netlify site. This PR updates the laravel submodule and therefore enables [docs-laravel](https://github.com/10gen/docs-laravel) to build on frontend-sourced Netlify sites(docs-frontend-stg, docs-frontend-dotcomstg, docs-frontend-dotcomprd)

The submodule is cloned in the same way as in this build script: https://github.com/10gen/docs-laravel/blob/v4.x/build.sh

### STAGING LINKS
[docs-frontend-dotcomstg laravel permalink](https://6760769ffcf9dd0008931a6f--docs-frontend-dotcomstg.netlify.app/). Deployed with netlify-test-deploy on Slack
[docs-frontend-stg laravel permalink](https://67608e080020195b4ac02cdd--docs-frontend-stg.netlify.app/) Deployed manually on netlify-testing-2 Snooty frontend branch